### PR TITLE
Feat: 프로필 페이지 구현 및 SSE 초기 설정 [FRONT-240]

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.2",
         "axios": "^1.5.0",
+        "event-source-polyfill": "^1.0.31",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-query": "^3.39.3",
@@ -35,6 +36,7 @@
         "workbox-streams": "^6.6.0"
       },
       "devDependencies": {
+        "@types/event-source-polyfill": "^1.0.1",
         "@types/node": "^20.5.9",
         "@types/react": "^18.2.21",
         "@types/react-dom": "^18.2.7",
@@ -3732,6 +3734,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
       "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+    },
+    "node_modules/@types/event-source-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.1.tgz",
+      "integrity": "sha512-dls8b0lUgJ/miRApF0efboQ9QZnAm7ofTO6P1ILu8bRPxUFKDxVwFf8+TeuuErmNui6blpltyr7+eV72dbQXlQ==",
+      "dev": true
     },
     "node_modules/@types/express": {
       "version": "4.17.17",
@@ -7817,6 +7825,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA=="
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.5.2",
     "axios": "^1.5.0",
+    "event-source-polyfill": "^1.0.31",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-query": "^3.39.3",
@@ -54,6 +55,7 @@
     ]
   },
   "devDependencies": {
+    "@types/event-source-polyfill": "^1.0.1",
     "@types/node": "^20.5.9",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",

--- a/client/src/api/alarm.ts
+++ b/client/src/api/alarm.ts
@@ -1,0 +1,47 @@
+import { AxiosResponse } from 'axios';
+import { api } from './api';
+
+interface Notification {
+  id: number;
+  content: string;
+  type: string;
+  receiver: string;
+  createAt: string;
+  read: boolean;
+}
+
+interface PageInfo {
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+interface AlarmsResponse {
+  status: {
+    httpStatus: string;
+    code: number;
+    message: string;
+  };
+  content: {
+    data: Notification[];
+    pageInfo: PageInfo;
+  };
+}
+
+const getAlarms = async (
+  profileId: number,
+  pageNum: number,
+): Promise<AlarmsResponse> => {
+  try {
+    const response: AxiosResponse<AlarmsResponse> = await api.get(
+      `/api/profiles/${profileId}/notifications?page=${pageNum}&size=5`,
+    );
+    return response.data;
+  } catch (error) {
+    console.log('프로필 알림 조회 실패', error);
+    throw error;
+  }
+};
+
+export { getAlarms };

--- a/client/src/api/profiles.ts
+++ b/client/src/api/profiles.ts
@@ -63,4 +63,35 @@ const newProfile = async (name: string): Promise<AxiosResponse> => {
   }
 };
 
-export { getProfiles, newProfile };
+// 프로필을 삭제하는 메서드
+const deleteProfile = async (profileId: number): Promise<AxiosResponse> => {
+  try {
+    const response = await api.delete(`/api/profiles/${profileId}`);
+    return response;
+  } catch (error) {
+    console.log('프로필 삭제 실패', error);
+    throw error;
+  }
+};
+
+// 닉네임 교체 메서드
+const newNickname = async (
+  profileId: number,
+  name: string,
+): Promise<AxiosResponse> => {
+  try {
+    const patchData = {
+      profileName: name,
+    };
+    const response = await api.patch(
+      `/api/profiles/${profileId}/names`,
+      patchData,
+    );
+    return response;
+  } catch (error) {
+    console.log('닉네임 변경 실패', error);
+    throw error;
+  }
+};
+
+export { getProfiles, newProfile, deleteProfile, newNickname };

--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -1,6 +1,16 @@
 import { AxiosResponse } from 'axios';
 import { api } from './api';
 
+// 로그아웃 메서드
+const logoutUser = async (): Promise<AxiosResponse> => {
+  try {
+    const response = await api.get(`/logout`);
+    return response;
+  } catch (error) {
+    console.log('로그아웃 실패', error);
+    throw error;
+  }
+};
 // 회원 탈퇴 메서드
 const deleteUser = async (): Promise<AxiosResponse> => {
   try {
@@ -12,4 +22,4 @@ const deleteUser = async (): Promise<AxiosResponse> => {
   }
 };
 
-export { deleteUser };
+export { logoutUser, deleteUser };

--- a/client/src/components/atoms/AlarmBoard.tsx
+++ b/client/src/components/atoms/AlarmBoard.tsx
@@ -1,0 +1,60 @@
+import styled from 'styled-components';
+import theme from '../../style/theme';
+
+interface AlarmBoardProps {
+  alarms: any[];
+}
+
+const AlarmBoardDiv = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: 610px;
+  height: 500px;
+  background-color: ${theme.colors.mainSkyblue};
+  border-radius: 25px;
+  padding: 8px;
+  border: 0;
+  margin: 10px;
+  position: relative;
+`;
+
+const AlarmBoardHeader = styled.span`
+  text-align: center; /* 가로 중앙 정렬 */
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* 세로 중앙 정렬 */
+  font-family: 'TmoneyRoundWindExtraBold';
+  font-size: 45px;
+  margin: 33px;
+  position: absolute;
+  top: 10px;
+`;
+
+const AlarmItemDiv = styled.div`
+  position: absolute;
+  top: 100px;
+  height: 400px;
+`;
+const AlarmItem = styled.div`
+  font-family: 'TmoneyRoundWindRegular';
+  font-size: 25px;
+  margin: 30px; /* 알림 아이템 사이의 간격 조절 */
+  width: 500px;
+`;
+
+const AlarmBoard = ({ alarms }: AlarmBoardProps) => {
+  return (
+    <AlarmBoardDiv>
+      <AlarmBoardHeader>알림함</AlarmBoardHeader>
+      <AlarmItemDiv>
+        {alarms.map((alarm) => (
+          <AlarmItem key={alarm.id}>{alarm.content}</AlarmItem>
+        ))}
+      </AlarmItemDiv>
+    </AlarmBoardDiv>
+  );
+};
+
+export default AlarmBoard;

--- a/client/src/components/atoms/AlarmBoard.tsx
+++ b/client/src/components/atoms/AlarmBoard.tsx
@@ -36,12 +36,31 @@ const AlarmItemDiv = styled.div`
   position: absolute;
   top: 100px;
   height: 400px;
+  padding: 10px;
 `;
 const AlarmItem = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  /* flex-direction: column; 컨텐츠를 위에서 아래로 나열하도록 수정 */
   font-family: 'TmoneyRoundWindRegular';
   font-size: 25px;
   margin: 30px; /* 알림 아이템 사이의 간격 조절 */
   width: 500px;
+  position: relative; /* 추가 */
+`;
+
+const AlarmContent = styled.div`
+  font-family: 'TmoneyRoundWindRegular';
+  font-size: 25px;
+  color: ${theme.colors.mainBlack};
+`;
+
+const AlarmCreateAt = styled.p`
+  text-align: center;
+  font-family: 'TmoneyRoundWindRegular';
+  font-size: 15px;
+  color: ${theme.colors.mainGray};
 `;
 
 const AlarmBoard = ({ alarms }: AlarmBoardProps) => {
@@ -50,7 +69,14 @@ const AlarmBoard = ({ alarms }: AlarmBoardProps) => {
       <AlarmBoardHeader>알림함</AlarmBoardHeader>
       <AlarmItemDiv>
         {alarms.map((alarm) => (
-          <AlarmItem key={alarm.id}>{alarm.content}</AlarmItem>
+          <AlarmItem key={alarm.id}>
+            {alarm.content && <AlarmContent>{alarm.content}</AlarmContent>}
+            {alarm.createAt && (
+              <AlarmCreateAt>
+                {alarm.createAt.slice(5, 7)}월 {alarm.createAt.slice(8, 10)}일
+              </AlarmCreateAt>
+            )}
+          </AlarmItem>
         ))}
       </AlarmItemDiv>
     </AlarmBoardDiv>

--- a/client/src/components/atoms/Button.tsx
+++ b/client/src/components/atoms/Button.tsx
@@ -4,7 +4,8 @@ import theme from '../../style/theme';
 interface ButtonProps {
   buttonText: string;
   color: string;
-  // onClick?: () => void;
+  borderColor?: string;
+  onClick?: () => void;
 }
 
 const StyledButton = styled.button<{ $bgColor: string }>`
@@ -27,11 +28,13 @@ const ButtonText = styled.span<{ $fontColor: string }>`
   margin-bottom: 24px;
   margin-right: 34px;
   margin-left: 34px;
+  white-space: pre-wrap;
 `;
 
-function Button({ buttonText, color }: ButtonProps) {
+function Button({ buttonText, color, borderColor, onClick }: ButtonProps) {
   let bgColor = theme.colors.mainBlue; // 기본값은 mainBlue
   let fontColor = theme.colors.mainWhite;
+  let buttonBorder = 'none';
 
   // color 값에 따라 bgColor를 설정
   switch (color) {
@@ -59,6 +62,10 @@ function Button({ buttonText, color }: ButtonProps) {
       bgColor = theme.storeColors.gray;
       fontColor = theme.colors.mainBlack;
       break;
+    case 'lightGray':
+      bgColor = theme.colors.mainGray;
+      fontColor = theme.colors.mainWhite;
+      break;
     case 'darkGray':
       bgColor = theme.colors.darkGray;
       break;
@@ -66,11 +73,23 @@ function Button({ buttonText, color }: ButtonProps) {
       bgColor = theme.colors.mainBlue;
   }
 
+  if (borderColor) {
+    buttonBorder = `6px solid ${borderColor}`;
+  }
+
   return (
-    <StyledButton $bgColor={bgColor}>
+    <StyledButton
+      $bgColor={bgColor}
+      style={{ border: buttonBorder }}
+      onClick={onClick}
+    >
       <ButtonText $fontColor={fontColor}>{buttonText}</ButtonText>
     </StyledButton>
   );
 }
 
+Button.defaultProps = {
+  borderColor: undefined,
+  onClick: undefined,
+};
 export default Button;

--- a/client/src/components/atoms/Button.tsx
+++ b/client/src/components/atoms/Button.tsx
@@ -41,6 +41,10 @@ function Button({ buttonText, color, borderColor, onClick }: ButtonProps) {
     case 'blue':
       bgColor = theme.colors.mainBlue;
       break;
+    case 'skyblue':
+      bgColor = '#F5FBFF';
+      fontColor = theme.colors.mainBlack;
+      break;
     case 'salmon':
       bgColor = theme.colors.mainSalmon;
       break;

--- a/client/src/components/atoms/ProfileBtn.tsx
+++ b/client/src/components/atoms/ProfileBtn.tsx
@@ -3,6 +3,9 @@ import { useRecoilState } from 'recoil';
 import { UserProfileState } from '../../recoil/profile/atom';
 import theme from '../../style/theme';
 
+interface ProfileBtnProps {
+  onClick: React.MouseEventHandler<HTMLDivElement>;
+}
 const ProfileWrapper = styled.div`
   display: flex;
   align-items: center;
@@ -43,7 +46,7 @@ const ModalText = styled.span`
   color: ${(props) => props.theme.colors.mainBlack};
 `;
 
-function ProfileBtn() {
+function ProfileBtn({ onClick }: ProfileBtnProps) {
   const [userProfile, setUserProfile] = useRecoilState(UserProfileState);
   let bgColor = theme.colors.mainWhite; // 기본값은 mainBlue
 
@@ -74,7 +77,7 @@ function ProfileBtn() {
   }
   return (
     <ProfileWrapper>
-      <StyledCharacter $bgColor={bgColor}>
+      <StyledCharacter $bgColor={bgColor} onClick={onClick}>
         <CharacterImage $bgImage={userProfile.profileImg} />
       </StyledCharacter>
       <ModalText>{userProfile.nickname}</ModalText>

--- a/client/src/components/atoms/SmallViewLeftArrow.tsx
+++ b/client/src/components/atoms/SmallViewLeftArrow.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { ReactComponent as ViewLeftArrowIcon } from '../../assets/image/etc/ViewLeftArrow.svg';
+
+interface ViewLeftArrowProps {
+  onClick: () => void;
+  disabled: boolean | undefined;
+}
+
+const StyledViewLeftArrow = styled(ViewLeftArrowIcon)<ViewLeftArrowProps>`
+  cursor: pointer;
+  margin: 5px;
+  width: 60px;
+  height: 60px;
+
+  ${(props) =>
+    props.disabled &&
+    css`
+      fill: gray;
+      cursor: default;
+    `}
+`;
+
+const ViewLeftArrow = ({ onClick, disabled }: ViewLeftArrowProps) => {
+  const handleClick = () => {
+    if (!disabled) {
+      onClick();
+    }
+  };
+
+  return <StyledViewLeftArrow onClick={handleClick} disabled={disabled} />;
+};
+
+export default ViewLeftArrow;

--- a/client/src/components/atoms/SmallViewRightArrow.tsx
+++ b/client/src/components/atoms/SmallViewRightArrow.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { ReactComponent as ViewRightArrowIcon } from '../../assets/image/etc/ViewRightArrow.svg';
+
+interface ViewRightArrowProps {
+  onClick: () => void;
+  disabled: boolean | undefined;
+}
+
+const StyledViewRightArrow = styled(ViewRightArrowIcon)<ViewRightArrowProps>`
+  cursor: pointer;
+  margin: 5px;
+  width: 60px;
+  height: 60px;
+
+  ${(props) =>
+    props.disabled &&
+    css`
+      fill: gray;
+      cursor: default;
+    `}
+`;
+
+const ViewRightArrow = ({ onClick, disabled }: ViewRightArrowProps) => {
+  const handleClick = () => {
+    if (!disabled) {
+      onClick();
+    }
+  };
+
+  return <StyledViewRightArrow onClick={handleClick} disabled={disabled} />;
+};
+
+export default ViewRightArrow;

--- a/client/src/components/atoms/TextInputBox.tsx
+++ b/client/src/components/atoms/TextInputBox.tsx
@@ -30,7 +30,7 @@ const Input = styled.input`
   text-align: center;
   background-color: ${theme.colors.mainWhite};
   border-radius: 15px;
-  border: none;
+  border: 3px solid ${theme.colors.lightPurple};
   outline: none;
   padding: 0;
   margin: 0;

--- a/client/src/components/organisms/AlarmPageButton.tsx
+++ b/client/src/components/organisms/AlarmPageButton.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import styled from 'styled-components';
+import SmallViewLeftArrow from '../atoms/SmallViewLeftArrow';
+import SmallViewRightArrow from '../atoms/SmallViewRightArrow';
+
+interface PageChangeButtonProps {
+  leftOnClick: () => void;
+  rightOnClick: () => void;
+  leftDisabled?: boolean;
+  rightDisabled?: boolean;
+}
+
+const ButtonDiv = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 630px;
+  top: 50%;
+  position: absolute;
+  transform: translateY(-50%);
+  pointer-events: none;
+`;
+
+const PointableSpace = styled.div`
+  border: 0px;
+  margin: 0px;
+  pointer-events: auto;
+`;
+const PageChangeButton = ({
+  leftOnClick,
+  rightOnClick,
+  leftDisabled,
+  rightDisabled,
+}: PageChangeButtonProps) => {
+  return (
+    <ButtonDiv>
+      <PointableSpace>
+        <SmallViewLeftArrow onClick={leftOnClick} disabled={leftDisabled} />
+      </PointableSpace>
+      <PointableSpace>
+        <SmallViewRightArrow onClick={rightOnClick} disabled={rightDisabled} />
+      </PointableSpace>
+    </ButtonDiv>
+  );
+};
+
+PageChangeButton.defaultProps = {
+  leftDisabled: false,
+  rightDisabled: false,
+};
+
+export default PageChangeButton;

--- a/client/src/components/organisms/ConfirmModal.tsx
+++ b/client/src/components/organisms/ConfirmModal.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from 'styled-components';
+import WhiteModal from '../atoms/WhiteModal';
+import Button from '../atoms/Button';
+
+interface ConfirmModalProps {
+  noCheck: () => void;
+  okCheck: () => void;
+  title: string;
+}
+const ModalWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  position: relative;
+`;
+
+const ButtonWrapper = styled.div`
+  position: fixed;
+  top: 50%;
+  z-index: 301;
+  display: flex;
+  flex-direction: row;
+`;
+const ConfirmModal = ({ noCheck, okCheck, title }: ConfirmModalProps) => {
+  return (
+    <ModalWrapper>
+      <WhiteModal modalText={title} height={200} />
+      <ButtonWrapper>
+        <Button buttonText="취소" color="lightGray" onClick={noCheck} />
+        <Button buttonText="확인" color="salmon" onClick={okCheck} />
+      </ButtonWrapper>
+    </ModalWrapper>
+  );
+};
+export default ConfirmModal;

--- a/client/src/components/organisms/NameChangeModal.tsx
+++ b/client/src/components/organisms/NameChangeModal.tsx
@@ -1,0 +1,44 @@
+import styled from 'styled-components';
+import theme from '../../style/theme';
+import WhiteModal from '../atoms/WhiteModal';
+import NicknameInputBox from './NicknameInputBox';
+
+interface NameChangeModalProps {
+  inputValue: string;
+  onClick: () => void;
+  onTextInputChange: (text: string) => void;
+  title: string;
+}
+
+const ModalWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  position: relative;
+`;
+const InputWrapper = styled.div`
+  position: fixed;
+  top: 50%;
+  z-index: 301;
+`;
+const NameChangeModal = ({
+  title,
+  inputValue,
+  onClick,
+  onTextInputChange,
+}: NameChangeModalProps) => {
+  return (
+    <ModalWrapper>
+      <WhiteModal modalText={title} height={250} />
+      <InputWrapper>
+        <NicknameInputBox
+          inputValue={inputValue}
+          onButtonClick={onClick}
+          onInputChange={onTextInputChange}
+        />
+      </InputWrapper>
+    </ModalWrapper>
+  );
+};
+
+export default NameChangeModal;

--- a/client/src/pages/DrawingTopicMenuPage.tsx
+++ b/client/src/pages/DrawingTopicMenuPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import { UserProfileState } from '../recoil/profile/atom';
@@ -96,6 +97,7 @@ function DrawingTopicMenuPage() {
     topic: [],
     page: {},
   });
+  const navigate = useNavigate();
 
   const itemsPerPage = 4; // 한 페이지당 아이템 개수
   // 첫번째 페이지, 마지막 페이지 파악하는 변수
@@ -149,7 +151,11 @@ function DrawingTopicMenuPage() {
           <BalloonTail />
         </Balloon>
       </BalloonWrapper>
-      <ProfileBtn />
+      <ProfileBtn
+        onClick={() => {
+          navigate('/profile/manage');
+        }}
+      />
       <BearImg
         src={`${process.env.REACT_APP_IMG_URL}/service-image/mainBear.png`}
         alt="menuTreeIcon"

--- a/client/src/pages/MainMenuPage.tsx
+++ b/client/src/pages/MainMenuPage.tsx
@@ -90,9 +90,9 @@ function MainMenuPage() {
   useEffect(() => {
     connectEventSSE(userProfile.profileId);
 
-    return () => {
-      disconnectEventSSE();
-    };
+    // return () => {
+    //   disconnectEventSSE();
+    // };
   });
   return (
     <MainMenuWrapper>

--- a/client/src/pages/MainMenuPage.tsx
+++ b/client/src/pages/MainMenuPage.tsx
@@ -1,10 +1,14 @@
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
 import menuTreeIcon from '../assets/image/etc/menuTree.svg';
 import menuMountainIcon from '../assets/image/etc/mainMountain.svg';
 import MenuBox from '../components/organisms/MainMenuBox';
 import ExitBox from '../components/organisms/ExitBox';
 import ProfileBtn from '../components/atoms/ProfileBtn';
+import { connectEventSSE, disconnectEventSSE } from '../sse/mainSSE';
+import { UserProfileState } from '../recoil/profile/atom';
 
 interface SvgImageProps extends React.HTMLProps<HTMLImageElement> {
   'data-bottom'?: string;
@@ -80,7 +84,16 @@ const BalloonTail = styled.div`
 `;
 
 function MainMenuPage() {
+  const userProfile = useRecoilValue(UserProfileState);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    connectEventSSE(userProfile.profileId);
+
+    return () => {
+      disconnectEventSSE();
+    };
+  });
   return (
     <MainMenuWrapper>
       <BalloonWrapper>

--- a/client/src/pages/MainMenuPage.tsx
+++ b/client/src/pages/MainMenuPage.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import menuTreeIcon from '../assets/image/etc/menuTree.svg';
 import menuMountainIcon from '../assets/image/etc/mainMountain.svg';
@@ -79,6 +80,7 @@ const BalloonTail = styled.div`
 `;
 
 function MainMenuPage() {
+  const navigate = useNavigate();
   return (
     <MainMenuWrapper>
       <BalloonWrapper>
@@ -87,7 +89,11 @@ function MainMenuPage() {
           <BalloonTail />
         </Balloon>
       </BalloonWrapper>
-      <ProfileBtn />
+      <ProfileBtn
+        onClick={() => {
+          navigate('/profile/manage');
+        }}
+      />
       <BearImg
         src={`${process.env.REACT_APP_IMG_URL}/service-image/mainBear.png`}
         alt="menuTreeIcon"

--- a/client/src/pages/MyProfilePage.tsx
+++ b/client/src/pages/MyProfilePage.tsx
@@ -1,8 +1,153 @@
+import styled from 'styled-components';
+import { useRecoilState } from 'recoil';
+import theme from '../style/theme';
+import { UserProfileState } from '../recoil/profile/atom';
+import AlarmBoard from '../components/atoms/AlarmBoard';
+import AlarmPageButton from '../components/organisms/AlarmPageButton';
+import ExitBox from '../components/organisms/ExitBox';
+import Button from '../components/atoms/Button';
+import UserRupee from '../components/atoms/UserRupee';
+
+const MyProfileContainer = styled.div`
+  width: 100vw;
+  height: 100vh; /* 화면 높이만큼 컨테이너 높이 설정 */
+  display: flex;
+`;
+const LeftContainer = styled.div`
+  width: 50vw;
+  height: 100vh; /* 화면 높이만큼 컨테이너 높이 설정 */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+`;
+const RightContainer = styled.div`
+  width: 50vw;
+  height: 100vh; /* 화면 높이만큼 컨테이너 높이 설정 */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+const CenteredAlarmBoard = styled.div`
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  height: 520px;
+  margin-top: 22px;
+`;
+const CenteredProfileBoard = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  margin-top: 200px;
+`;
+
+const ExitBoxWrapper = styled.div`
+  position: fixed;
+  top: 3%;
+  left: 0%;
+`;
+
+const CharacterImage = styled.div<{ imgsrc: string }>`
+  width: 300px;
+  height: 300px;
+  background-image: url(${(props) => props.imgsrc}); // url() 함수 사용
+  background-size: cover; // 이미지 크기 조절
+  background-position: center; // 이미지 위치 조절
+`;
+
+const NicknameText = styled.span`
+  display: flex;
+  justify-content: center;
+  font-family: 'TmoneyRoundWindExtraBold';
+  font-size: 55px;
+  align-items: center;
+  color: ${(props) => props.theme.colors.mainBlack};
+`;
+
 function MyProfilePage() {
+  const [userProfile, setUserProfile] = useRecoilState(UserProfileState);
   return (
-    <div>
-      <h1>MyProfilePage</h1>
-    </div>
+    <MyProfileContainer>
+      <LeftContainer>
+        <ExitBoxWrapper>
+          <ExitBox color="dark" />
+        </ExitBoxWrapper>
+        <UserRupee />
+        {userProfile.profileImg && (
+          <CenteredProfileBoard>
+            <NicknameText>{userProfile.nickname}</NicknameText>
+            <CharacterImage imgsrc={userProfile.profileImg} />
+            <Button buttonText="d" color="f" />
+          </CenteredProfileBoard>
+        )}
+      </LeftContainer>
+      <RightContainer>
+        <CenteredAlarmBoard>
+          <AlarmBoard
+            alarms={[
+              {
+                id: 8, // notificationId
+                content:
+                  '길몬 아바타가 출시되었습니다 길몬 아바타가 출시되었습니다.',
+                type: 'NEW_AVATAR',
+                receiver: '엄한결님',
+                createAt: '2023-09-15T00:18:20.204304',
+                read: false,
+              },
+              {
+                id: 9,
+                content: '아하아아아아아아아 그림주제가 출시되었습니다.',
+                type: 'NEW_SUBJECT',
+                receiver: '엄한결님',
+                createAt: '2023-09-15T13:20:50.839429',
+                read: false,
+              },
+              {
+                id: 10,
+                content: '이으ㅇㅣ 그림주제가 출시되었습니다.',
+                type: 'NEW_SUBJECT',
+                receiver: '엄한결님',
+                createAt: '2023-09-15T13:21:09.349908',
+                read: false,
+              },
+              {
+                id: 11,
+                content:
+                  '김철수 아바타 철수 아바타 철수 아바타 철수 아바타가 출시되었습니다.',
+                type: 'NEW_AVATAR',
+                receiver: '엄한결님',
+                createAt: '2023-09-15T13:21:42.890412',
+                read: false,
+              },
+              {
+                id: 12,
+                content: '에 아바타가 출시되었습니다.',
+                type: 'NEW_AVATAR',
+                receiver: '엄한결님',
+                createAt: '2023-09-15T13:21:42.890412',
+                read: false,
+              },
+            ]}
+          />
+          <AlarmPageButton
+            leftOnClick={() => {
+              console.log('left');
+            }}
+            rightOnClick={() => {
+              console.log('right');
+            }}
+          />
+        </CenteredAlarmBoard>
+        <Button buttonText="       내 그림 보러가기       " color="blue" />
+        <Button
+          buttonText="             로그아웃             "
+          color="darkGray"
+        />
+      </RightContainer>
+    </MyProfileContainer>
   );
 }
 

--- a/client/src/pages/MyProfilePage.tsx
+++ b/client/src/pages/MyProfilePage.tsx
@@ -22,6 +22,7 @@ const sampleData = [
   {
     id: 1,
     content: '수신한 알림이 없습니다.',
+    createdAt: '2023-09-21',
   },
 ];
 const MyProfileContainer = styled.div`
@@ -119,6 +120,7 @@ function MyProfilePage() {
         const response = await getAlarms(profileId, currentPage);
         const loadedData = { ...response.content };
         await setAlarms(loadedData);
+        console.log(loadedData);
       } catch (error) {
         console.log(error);
       }

--- a/client/src/pages/MyProfilePage.tsx
+++ b/client/src/pages/MyProfilePage.tsx
@@ -1,13 +1,33 @@
 import styled from 'styled-components';
-import { useRecoilState } from 'recoil';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilState, useResetRecoilState } from 'recoil';
 import theme from '../style/theme';
 import { UserProfileState } from '../recoil/profile/atom';
 import AlarmBoard from '../components/atoms/AlarmBoard';
 import AlarmPageButton from '../components/organisms/AlarmPageButton';
 import ExitBox from '../components/organisms/ExitBox';
+import ExitBoxOnBlur from '../components/organisms/ExitBoxOnBlur';
 import Button from '../components/atoms/Button';
 import UserRupee from '../components/atoms/UserRupee';
+import DeleteText from '../components/atoms/DeleteText';
+import BlurBox from '../components/atoms/BlurBox';
+import NameChangeModal from '../components/organisms/NameChangeModal';
+import ConfirmModal from '../components/organisms/ConfirmModal';
+import { deleteProfile, newNickname } from '../api/profiles';
+import { logoutUser } from '../api/user';
+import { getAlarms } from '../api/alarm';
 
+const sampleData = [
+  {
+    id: 8, // notificationId
+    content: '수신한 알림이 없습니다.',
+    type: 'sample',
+    receiver: 'sample',
+    createAt: '2023-09-15T00:18:20.204304',
+    read: false,
+  },
+];
 const MyProfileContainer = styled.div`
   width: 100vw;
   height: 100vh; /* 화면 높이만큼 컨테이너 높이 설정 */
@@ -20,6 +40,7 @@ const LeftContainer = styled.div`
   flex-direction: column;
   align-items: center;
   position: relative;
+  background-color: ${theme.hamsterColors.sky};
 `;
 const RightContainer = styled.div`
   width: 50vw;
@@ -41,7 +62,7 @@ const CenteredProfileBoard = styled.div`
   align-items: center;
   justify-content: center;
   position: relative;
-  margin-top: 200px;
+  margin-top: 120px;
 `;
 
 const ExitBoxWrapper = styled.div`
@@ -67,10 +88,155 @@ const NicknameText = styled.span`
   color: ${(props) => props.theme.colors.mainBlack};
 `;
 
+const ExitBoxOnBlurWrapper = styled.div`
+  position: fixed;
+  top: 3%;
+  left: 0%;
+  z-index: 300;
+`;
+
+const WhiteModalWrapper = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 300;
+  transform: translate(-50%, -50%);
+`;
+
 function MyProfilePage() {
+  // 프로필 관리
   const [userProfile, setUserProfile] = useRecoilState(UserProfileState);
+  // 출력 관리 state
+  const [changeName, setChangeName] = useState<boolean>(false);
+  const [textInputValue, setTextInputValue] = useState<string>('');
+  const [isDelete, setIsDelete] = useState<boolean>(false);
+  const [isLogout, setIsLogout] = useState<boolean>(false);
+  // 알림 state
+  const [currentPage, setCurrentPage] = useState(0);
+  const [alarms, setAlarms] = useState<any>({});
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function loadData(profileId: number) {
+      try {
+        const response = await getAlarms(profileId, currentPage);
+        const loadedData = { ...response.content };
+        await setAlarms(loadedData);
+      } catch (error) {
+        console.log(error);
+      }
+    }
+    loadData(userProfile.profileId);
+  }, [currentPage]);
+  const isFirstPage = currentPage === 0;
+  const isLastPage = alarms.pageInfo
+    ? currentPage === alarms.pageInfo.totalPages - 1
+    : false;
+  // const isLastPage = false;
+  // 화살표에 전달할 boolean 값
+  const leftDisabled = isFirstPage;
+  const rightDisabled = isLastPage;
+  const leftOnClick = () => {
+    const prevPage = currentPage - 1;
+    setCurrentPage(prevPage);
+  };
+
+  const rightOnClick = () => {
+    const nextPage = currentPage + 1;
+    setCurrentPage(nextPage);
+  };
+  const handleChangeName = () => {
+    setChangeName(true);
+  };
+  const handleChangeChar = () => {
+    navigate('/profile/character');
+  };
+  const handleMyPicture = () => {
+    navigate('/profile/drawings');
+  };
+
+  const resetRecoil = useResetRecoilState(UserProfileState);
+
+  const handleLogout = () => {
+    resetRecoil();
+    localStorage.removeItem('accessToken');
+    window.location.href = `https://kauth.kakao.com/oauth/logout?client_id=${process.env.REACT_APP_KAUTH_ID}&logout_redirect_uri=${process.env.REACT_APP_API_URL}/logout`;
+  };
+
+  const handleDeleteProfile = (profileId: number) => {
+    deleteProfile(profileId);
+    navigate('/profiles');
+  };
+
+  const handleNewName = async (profileId: number, inputText: string) => {
+    try {
+      const response = await newNickname(profileId, inputText);
+      alert('닉네임이 성공적으로 변경되었습니다');
+      setUserProfile((prevProfile) => ({
+        ...prevProfile,
+        nickname: inputText,
+      }));
+      setTextInputValue('');
+      setChangeName(false);
+    } catch (error) {
+      alert(error);
+    }
+  };
+
   return (
     <MyProfileContainer>
+      {changeName && (
+        <>
+          <BlurBox />
+          <ExitBoxOnBlurWrapper>
+            <ExitBoxOnBlur
+              color="light"
+              onClick={() => {
+                setChangeName(false);
+              }}
+            />
+          </ExitBoxOnBlurWrapper>
+          <WhiteModalWrapper>
+            <NameChangeModal
+              title="이름을 지어주세요!"
+              inputValue={textInputValue}
+              onTextInputChange={setTextInputValue}
+              onClick={() =>
+                handleNewName(userProfile.profileId, textInputValue)
+              }
+            />
+          </WhiteModalWrapper>
+        </>
+      )}
+      {isDelete && (
+        <>
+          <BlurBox />
+          <WhiteModalWrapper>
+            <ConfirmModal
+              title={`${userProfile.nickname} 프로필을 삭제할까요?`}
+              noCheck={() => setIsDelete(false)}
+              okCheck={() => {
+                handleDeleteProfile(userProfile.profileId);
+              }}
+            />
+          </WhiteModalWrapper>
+        </>
+      )}
+      {isLogout && (
+        <>
+          <BlurBox />
+          <WhiteModalWrapper>
+            <ConfirmModal
+              title="정말로 로그아웃 할까요?"
+              noCheck={() => setIsLogout(false)}
+              okCheck={() => {
+                handleLogout();
+              }}
+            />
+          </WhiteModalWrapper>
+        </>
+      )}
       <LeftContainer>
         <ExitBoxWrapper>
           <ExitBox color="dark" />
@@ -80,71 +246,49 @@ function MyProfilePage() {
           <CenteredProfileBoard>
             <NicknameText>{userProfile.nickname}</NicknameText>
             <CharacterImage imgsrc={userProfile.profileImg} />
-            <Button buttonText="d" color="f" />
+            <Button
+              buttonText="      캐릭터 변경      "
+              color="skyblue"
+              onClick={handleChangeChar}
+            />
+            <Button
+              buttonText="      닉네임 변경      "
+              color="skyblue"
+              onClick={handleChangeName}
+            />
           </CenteredProfileBoard>
         )}
+        <DeleteText
+          onClick={() => {
+            setIsDelete(true);
+          }}
+          content="프로필 삭제하기"
+        />
       </LeftContainer>
       <RightContainer>
         <CenteredAlarmBoard>
-          <AlarmBoard
-            alarms={[
-              {
-                id: 8, // notificationId
-                content:
-                  '길몬 아바타가 출시되었습니다 길몬 아바타가 출시되었습니다.',
-                type: 'NEW_AVATAR',
-                receiver: '엄한결님',
-                createAt: '2023-09-15T00:18:20.204304',
-                read: false,
-              },
-              {
-                id: 9,
-                content: '아하아아아아아아아 그림주제가 출시되었습니다.',
-                type: 'NEW_SUBJECT',
-                receiver: '엄한결님',
-                createAt: '2023-09-15T13:20:50.839429',
-                read: false,
-              },
-              {
-                id: 10,
-                content: '이으ㅇㅣ 그림주제가 출시되었습니다.',
-                type: 'NEW_SUBJECT',
-                receiver: '엄한결님',
-                createAt: '2023-09-15T13:21:09.349908',
-                read: false,
-              },
-              {
-                id: 11,
-                content:
-                  '김철수 아바타 철수 아바타 철수 아바타 철수 아바타가 출시되었습니다.',
-                type: 'NEW_AVATAR',
-                receiver: '엄한결님',
-                createAt: '2023-09-15T13:21:42.890412',
-                read: false,
-              },
-              {
-                id: 12,
-                content: '에 아바타가 출시되었습니다.',
-                type: 'NEW_AVATAR',
-                receiver: '엄한결님',
-                createAt: '2023-09-15T13:21:42.890412',
-                read: false,
-              },
-            ]}
-          />
+          {alarms.data ? (
+            <AlarmBoard alarms={alarms.data} />
+          ) : (
+            <AlarmBoard alarms={sampleData} />
+          )}
+          {/* <AlarmBoard alarms={sampleData} /> */}
           <AlarmPageButton
-            leftOnClick={() => {
-              console.log('left');
-            }}
-            rightOnClick={() => {
-              console.log('right');
-            }}
+            leftOnClick={leftOnClick}
+            rightOnClick={rightOnClick}
+            leftDisabled={leftDisabled}
+            rightDisabled={rightDisabled}
           />
         </CenteredAlarmBoard>
-        <Button buttonText="       내 그림 보러가기       " color="blue" />
+        <Button
+          buttonText="       내 그림 보러가기       "
+          color="blue"
+          onClick={handleMyPicture}
+        />
         <Button
           buttonText="             로그아웃             "
           color="darkGray"
+          onClick={() => setIsLogout(true)}
         />
       </RightContainer>
     </MyProfileContainer>

--- a/client/src/pages/MyProfilePage.tsx
+++ b/client/src/pages/MyProfilePage.tsx
@@ -20,12 +20,8 @@ import { getAlarms } from '../api/alarm';
 
 const sampleData = [
   {
-    id: 8, // notificationId
+    id: 1,
     content: '수신한 알림이 없습니다.',
-    type: 'sample',
-    receiver: 'sample',
-    createAt: '2023-09-15T00:18:20.204304',
-    read: false,
   },
 ];
 const MyProfileContainer = styled.div`
@@ -74,9 +70,9 @@ const ExitBoxWrapper = styled.div`
 const CharacterImage = styled.div<{ imgsrc: string }>`
   width: 300px;
   height: 300px;
-  background-image: url(${(props) => props.imgsrc}); // url() 함수 사용
-  background-size: cover; // 이미지 크기 조절
-  background-position: center; // 이미지 위치 조절
+  background-image: url(${(props) => props.imgsrc});
+  background-size: cover;
+  background-position: center;
 `;
 
 const NicknameText = styled.span`
@@ -133,8 +129,6 @@ function MyProfilePage() {
   const isLastPage = alarms.pageInfo
     ? currentPage === alarms.pageInfo.totalPages - 1
     : false;
-  // const isLastPage = false;
-  // 화살표에 전달할 boolean 값
   const leftDisabled = isFirstPage;
   const rightDisabled = isLastPage;
   const leftOnClick = () => {
@@ -156,17 +150,17 @@ function MyProfilePage() {
     navigate('/profile/drawings');
   };
 
-  const resetRecoil = useResetRecoilState(UserProfileState);
+  const resetUserRecoil = useResetRecoilState(UserProfileState);
 
   const handleLogout = () => {
-    resetRecoil();
+    resetUserRecoil();
     localStorage.removeItem('accessToken');
     window.location.href = `https://kauth.kakao.com/oauth/logout?client_id=${process.env.REACT_APP_KAUTH_ID}&logout_redirect_uri=${process.env.REACT_APP_API_URL}/logout`;
   };
 
   const handleDeleteProfile = (profileId: number) => {
     deleteProfile(profileId);
-    navigate('/profiles');
+    navigate('/login');
   };
 
   const handleNewName = async (profileId: number, inputText: string) => {
@@ -180,7 +174,7 @@ function MyProfilePage() {
       setTextInputValue('');
       setChangeName(false);
     } catch (error) {
-      alert(error);
+      alert('닉네임 변경에 실패했습니다. 다른 닉네임으로 시도해주세요');
     }
   };
 
@@ -267,7 +261,7 @@ function MyProfilePage() {
       </LeftContainer>
       <RightContainer>
         <CenteredAlarmBoard>
-          {alarms.data ? (
+          {alarms.data && alarms.data.length > 0 ? (
             <AlarmBoard alarms={alarms.data} />
           ) : (
             <AlarmBoard alarms={sampleData} />

--- a/client/src/pages/WatchingMenuPage.tsx
+++ b/client/src/pages/WatchingMenuPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import { UserProfileState } from '../recoil/profile/atom';
@@ -96,6 +97,7 @@ function WatchingMenuPage() {
     topic: [],
     page: {},
   });
+  const navigate = useNavigate();
 
   const itemsPerPage = 4; // 한 페이지당 아이템 개수
   // 첫번째 페이지, 마지막 페이지 파악하는 변수
@@ -150,7 +152,11 @@ function WatchingMenuPage() {
           <BalloonTail />
         </Balloon>
       </BalloonWrapper>
-      <ProfileBtn />
+      <ProfileBtn
+        onClick={() => {
+          navigate('/profile/manage');
+        }}
+      />
       <BearImg
         src={`${process.env.REACT_APP_IMG_URL}/service-image/mainBear.png`}
         alt="menuTreeIcon"

--- a/client/src/sse/mainSSE.tsx
+++ b/client/src/sse/mainSSE.tsx
@@ -1,0 +1,34 @@
+import { EventSourcePolyfill } from 'event-source-polyfill';
+
+const SERVER_URL = process.env.REACT_APP_API_URL;
+let eventSource: EventSourcePolyfill | null = null;
+
+export function connectEventSSE(profileId: number): void {
+  eventSource = new EventSourcePolyfill(
+    `${SERVER_URL}/api/profiles/${profileId}/sse/connects`,
+    {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+      },
+      withCredentials: true,
+    },
+  );
+  eventSource.onopen = () => {
+    console.log('알람 연결 성공');
+  };
+  eventSource.onmessage = (event: any) => {
+    const parsedData = JSON.parse(event.data);
+    console.log('서버에서 이벤트 수신:', parsedData);
+  };
+
+  eventSource.onerror = (error: any) => {
+    console.error('SSE 연결 오류:', error);
+  };
+}
+
+export function disconnectEventSSE(): void {
+  if (eventSource) {
+    eventSource.close();
+    eventSource = null; // eventSource 변수를 초기화하여 재사용 방지
+  }
+}

--- a/client/src/sse/mainSSE.tsx
+++ b/client/src/sse/mainSSE.tsx
@@ -3,6 +3,12 @@ import { EventSourcePolyfill } from 'event-source-polyfill';
 const SERVER_URL = process.env.REACT_APP_API_URL;
 let eventSource: EventSourcePolyfill | null = null;
 
+interface MessageEvent {
+  type: string;
+  target: any;
+  data: string;
+  lastEventId: string;
+}
 export function connectEventSSE(profileId: number): void {
   eventSource = new EventSourcePolyfill(
     `${SERVER_URL}/api/profiles/${profileId}/sse/connects`,
@@ -10,18 +16,22 @@ export function connectEventSSE(profileId: number): void {
       headers: {
         Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
       },
+      heartbeatTimeout: 30000000,
       withCredentials: true,
     },
   );
   eventSource.onopen = () => {
     console.log('알람 연결 성공');
   };
-  eventSource.onmessage = (event: any) => {
+  eventSource.onmessage = (event) => {
     const parsedData = JSON.parse(event.data);
     console.log('서버에서 이벤트 수신:', parsedData);
   };
+  eventSource.addEventListener('initial', (event) => {
+    console.log('연결 시 서버에서 쏘는 데이터', event);
+  });
 
-  eventSource.onerror = (error: any) => {
+  eventSource.onerror = (error) => {
     console.error('SSE 연결 오류:', error);
   };
 }


### PR DESCRIPTION
### Changes
프로필 페이지 구현 및 메인 페이지 SSE 초기 설정
패키지 설치 : event-source-polyfill
타 페이지 수정 : MainMenuPage
페이지 형성 : MyProfilePage (관련 atoms/organisms 생성)
유틸 생성/수정 : sse, api/profiles

나중에 고칠 거 : 
프로필 페이지 좌측 background-color 임의값 넣은 부분, 
캐릭터/닉네임 변경 버튼 theme color 임의값 넣은 부분, 
로그아웃 시 recoil/token 정보 다 제거해도 현재 서비스만 로그아웃 누르면 로그인 시 input 없이 자동 로그인되는 거 
<br>

### Test Checklist ☑️
- [x] 메인메뉴 페이지 건드린 거 중에 건드리지 말아야 할 거를 건드렸는지 확인해주세요
- [x] 프로필 페이지에서 구현 요소 중 누락된 점이 있는지 확인해주세요

### Screenshot(option)
![FRONT-240(1)](https://github.com/BbeumbungE/Frontend/assets/122246882/8695f64e-5f59-41b0-8ee5-fab7159a6873)
![FRONT-240(2)](https://github.com/BbeumbungE/Frontend/assets/122246882/e1f99b3b-9fb3-43f6-9b61-82a903f16ff8)
![FRONT-240(3)](https://github.com/BbeumbungE/Frontend/assets/122246882/c4a79150-f1d3-4545-ba33-7d8c68c0d97c)
![FRONT-240(4)](https://github.com/BbeumbungE/Frontend/assets/122246882/a3c6f11d-6799-46a0-9276-6f63f89e6c53)

<br>
